### PR TITLE
Show repo root folder when short path is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ omf theme default
 ## Screenshot
 
 <p align="center">
-<img src="https://cloud.githubusercontent.com/assets/526122/9554176/e3fffb44-4dbb-11e5-88c7-57f2b35ad2b8.png">
+<img src="https://cloud.githubusercontent.com/assets/526122/9604024/ac338638-50ac-11e5-874a-70fa9287db93.png">
 </p>
 
 ## Configuration

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -31,9 +31,17 @@ function fish_prompt
     echo -n -s $error_color $fish $normal_color
   end
 
-  echo -n -s " " $directory_color $cwd $normal_color
-
   if git_is_repo
+    if test "$theme_short_path" = 'yes'
+      set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+      set parent_root_folder (dirname $root_folder)
+      set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
+
+      echo -n -s " " $directory_color $cwd $normal_color
+    else
+      echo -n -s " " $directory_color $cwd $normal_color
+    end
+
     echo -n -s " on " $repository_color (git_branch_name) $normal_color " "
 
     if git_is_touched
@@ -41,6 +49,8 @@ function fish_prompt
     else
       echo -n -s (git_ahead $ahead $behind $diverged $none)
     end
+  else
+    echo -n -s " " $directory_color $cwd $normal_color
   end
 
   echo -n -s " "


### PR DESCRIPTION
For git-tracked folders, show the full path since the root folder:
⋊> omf/bin

instead of:
⋊> bin
