### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -20,10 +20,10 @@ function fish_prompt
   set -l none     "◦"
 
   set -l normal_color     (set_color normal)
-  set -l success_color    (set_color $fish_pager_color_progress ^/dev/null; or set_color cyan)
-  set -l error_color      (set_color $fish_color_error ^/dev/null; or set_color red --bold)
-  set -l directory_color  (set_color $fish_color_quote ^/dev/null; or set_color brown)
-  set -l repository_color (set_color $fish_color_cwd ^/dev/null; or set_color green)
+  set -l success_color    (set_color $fish_pager_color_progress 2> /dev/null; or set_color cyan)
+  set -l error_color      (set_color $fish_color_error 2> /dev/null; or set_color red --bold)
+  set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
+  set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)
 
   if test $last_command_status -eq 0
     echo -n -s $success_color $fish $normal_color
@@ -33,7 +33,7 @@ function fish_prompt
 
   if git_is_repo
     if test "$theme_short_path" = 'yes'
-      set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+      set root_folder (command git rev-parse --show-toplevel 2> /dev/null)
       set parent_root_folder (dirname $root_folder)
       set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
     end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,5 +1,5 @@
 function fish_right_prompt
-  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
+  set_color $fish_color_autosuggestion 2> /dev/null; or set_color 555
   date "+%H:%M:%S"
   set_color normal
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618