### PR TITLE
Remove usage of fish pager colors

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -23,7 +23,7 @@ function fish_prompt
   set -l none     "◦"
 
   set -l normal_color     (set_color normal)
-  set -l success_color    (set_color $fish_pager_color_progress 2> /dev/null; or set_color cyan)
+  set -l success_color    (set_color cyan)
   set -l error_color      (set_color $fish_color_error 2> /dev/null; or set_color red --bold)
   set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -23,7 +23,7 @@ function fish_prompt
   set -l none     "◦"
 
   set -l normal_color     (set_color normal)
-  set -l success_color    (set_color cyan 2> /dev/null; or set_color cyan)
+  set -l success_color    (set_color cyan)
   set -l error_color      (set_color $fish_color_error 2> /dev/null; or set_color red --bold)
   set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -23,7 +23,7 @@ function fish_prompt
   set -l none     "◦"
 
   set -l normal_color     (set_color normal)
-  set -l success_color    (set_color cyan)
+  set -l success_color    (set_color $fish_color_param 2> /dev/null; or set_color cyan)
   set -l error_color      (set_color $fish_color_error 2> /dev/null; or set_color red --bold)
   set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -23,7 +23,7 @@ function fish_prompt
   set -l none     "◦"
 
   set -l normal_color     (set_color normal)
-  set -l success_color    (set_color $fish_color_param 2> /dev/null; or set_color cyan)
+  set -l success_color    (set_color cyan 2> /dev/null; or set_color cyan)
   set -l error_color      (set_color $fish_color_error 2> /dev/null; or set_color red --bold)
   set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)


### PR DESCRIPTION
Fish 2.4 changed the default styling of the built in pager. This was fine by itself, but the default theme was using the pager colors inside the prompt, which resulted in a color scheme that was no longer pleasing. This modifies the theme to use a specific color instead.

See https://github.com/oh-my-fish/oh-my-fish/issues/440 for more details.

Fixes #11.