### PR TITLE
fish_prompt: Make users aware they're in an SSH session

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Display `git stash` indicator:
   set -g theme_stash_indicator yes
 ```
 
+Do not display the `user at hostname` when in an SSH session:
+```
+  set -g theme_ignore_ssh_awareness yes
+```
+
 # License
 
 [MIT][mit] © [bpinto][author] et [al][contributors]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Display `git stash` indicator:
   set -g theme_stash_indicator yes
 ```
 
-Do not display the `user at hostname` when in an SSH session:
+Do not display `user@hostname` when in an SSH session:
 ```
   set -g theme_ignore_ssh_awareness yes
 ```

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -2,6 +2,7 @@
 #
 #  set -g theme_short_path yes
 #  set -g theme_stash_indicator yes
+#  set -g theme_ignore_ssh_awareness yes
 
 function fish_prompt
   set -l last_command_status $status
@@ -27,10 +28,24 @@ function fish_prompt
   set -l directory_color  (set_color $fish_color_quote 2> /dev/null; or set_color brown)
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)
 
+  set -l prompt_string $fish
+  set -l append_final_fish no
+
+  if test "$theme_ignore_ssh_awareness" != 'yes'
+    if test -n "$SSH_CLIENT" || test -n "$SSH_TTY"
+      set prompt_string "$prompt_string" (whoami)"@"(hostname -s)
+      set append_final_fish yes
+    end
+  end
+
+  if test "$append_final_fish" = 'yes'
+    set prompt_string "$prompt_string $fish"
+  end
+
   if test $last_command_status -eq 0
-    echo -n -s $success_color $fish $normal_color
+    echo -n -s $success_color $prompt_string $normal_color
   else
-    echo -n -s $error_color $fish $normal_color
+    echo -n -s $error_color $prompt_string $normal_color
   end
 
   if git_is_repo

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -31,7 +31,7 @@ function fish_prompt
   set -l prompt_string $fish
 
   if test "$theme_ignore_ssh_awareness" != 'yes' -a -n "$SSH_CLIENT$SSH_TTY"
-    set prompt_string "$prompt_string "(whoami)"@"(hostname -s)" $fish"
+    set prompt_string "$fish "(whoami)"@"(hostname -s)" $fish"
   end
 
   if test $last_command_status -eq 0

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -29,17 +29,9 @@ function fish_prompt
   set -l repository_color (set_color $fish_color_cwd 2> /dev/null; or set_color green)
 
   set -l prompt_string $fish
-  set -l append_final_fish no
 
-  if test "$theme_ignore_ssh_awareness" != 'yes'
-    if test -n "$SSH_CLIENT" || test -n "$SSH_TTY"
-      set prompt_string "$prompt_string" (whoami)"@"(hostname -s)
-      set append_final_fish yes
-    end
-  end
-
-  if test "$append_final_fish" = 'yes'
-    set prompt_string "$prompt_string $fish"
+  if test "$theme_ignore_ssh_awareness" != 'yes' -a -n "$SSH_CLIENT$SSH_TTY"
+    set prompt_string "$prompt_string "(whoami)"@"(hostname -s)" $fish"
   end
 
   if test $last_command_status -eq 0


### PR DESCRIPTION
We can easily inform users they're in an SSH session by displaying the
'user at hostname' string as part of the prompt string.

The way chosen to do this here is checking "$SSH_CLIENT" and act
accordingly to whether it's set or not.

The proposed changes do not change any of the colours, but there's a
noticeable difference on the prompt itself, as shown below:
* Before this patch:
⋊> ~

* After this patch:
⋊> fidencio at pessoa ⋊> ~

It's important to make it very much clear that this difference only
happens when the user is connected to a fish terminal via SSH.

Fixes: #22

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>