### PR TITLE
fish_right_prompt: Make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Display `git stash` indicator:
   set -g theme_stash_indicator yes
 ```
 
+Hide the right prompt:
+```
+  set -g theme_hide_right_prompt yes
+```
+
 # License
 
 [MIT][mit] © [bpinto][author] et [al][contributors]

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -1,4 +1,12 @@
+# You can override some default options with config.fish:
+#
+#  set -g theme_hide_right_prompt yes
+
 function fish_right_prompt
+  if test "$theme_hide_right_prompt" = 'yes'
+    return
+  end
+
   set_color $fish_color_autosuggestion 2> /dev/null; or set_color 555
   date "+%H:%M:%S"
   set_color normal


### PR DESCRIPTION
Allow users to easily decide whether or not the `fish_right_prompt`
should be displayed.

The current way to do so is creating an empty `fish_right_prompt`
function in `~/.config/fish/functions/fish_mode_prompt.fish`, which
although is very well documented and the default way to do so, is less
handy than having an option on the theme to do so.

Fixes: #24 

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>